### PR TITLE
Add Web UI support (Filestash) with TLS and PVC options

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5,7 +5,7 @@ entries:
       category: storage
     apiVersion: v2
     appVersion: 1.10.0
-    created: "2025-05-05T03:34:47.559286525+02:00"
+    created: "2025-05-05T04:23:10.122478191+02:00"
     description: A Helm chart for deploying Storj Gateway with Vault-injected secrets
     digest: b0985ee334b13104d25d31948223fa463f696c120344de399bd11c591b125159
     home: https://www.storj.io/
@@ -30,7 +30,32 @@ entries:
       category: storage
     apiVersion: v2
     appVersion: 1.10.0
-    created: "2025-05-05T03:53:59.703085695+02:00"
+    created: "2025-05-05T04:23:10.119895917+02:00"
+    description: A Helm chart for deploying Storj Gateway with Vault-injected secrets
+    digest: 23fbf376d82f35f2e8492eb7fc571400d1b1e86e5be0294df7f58d8837110e2a
+    home: https://www.storj.io/
+    icon: https://www.storj.io/favicon.ico
+    keywords:
+    - storj
+    - gateway
+    - vault
+    - s3
+    kubeVersion: '>= 1.21.0'
+    maintainers:
+    - email: mhorcajada@gh.com
+      name: Miguel Horcajada
+      url: https://github.com/mhorcajada
+    name: storj-gateway
+    sources:
+    - https://github.com/storj/storj
+    urls:
+    - https://mhorcajada.github.io/charts/storj-gateway-0.1.1.tgz
+    version: 0.1.1
+  - annotations:
+      category: storage
+    apiVersion: v2
+    appVersion: 1.10.0
+    created: "2025-05-05T04:23:10.115661423+02:00"
     description: A Helm chart for deploying Storj Gateway with Vault-injected secrets
     digest: 1c68a757187036e063c32e19511fab1aca753f107ff7657d5f47495b445c663f
     home: https://www.storj.io/
@@ -51,4 +76,4 @@ entries:
     urls:
     - https://mhorcajada.github.io/charts/storj-gateway-0.1.0.tgz
     version: 0.1.0
-generated: "2025-05-05T03:53:59.698908496+02:00"
+generated: "2025-05-05T04:23:10.111922663+02:00"

--- a/storj-gateway/Chart.yaml
+++ b/storj-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: storj-gateway
 description: A Helm chart for deploying Storj Gateway with Vault-injected secrets
-version: 0.1.2
+version: 0.2.0
 appVersion: "1.10.0"
 kubeVersion: ">= 1.21.0"
 keywords:

--- a/storj-gateway/templates/webui-deployment.yaml
+++ b/storj-gateway/templates/webui-deployment.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.envSecret (hasKey .Values.envSecret "enabled") .Values.envSecret.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "storj-gateway.fullname" . }}-webui
+  labels:
+    app: {{ include "storj-gateway.name" . }}-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "storj-gateway.name" . }}-webui
+  template:
+    metadata:
+      labels:
+        app: {{ include "storj-gateway.name" . }}-webui
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: filestash
+          image: {{ .Values.webUi.image.repository }}:{{ .Values.webUi.image.tag }}
+          image: >
+            {{- if .Values.webUi.image.digest -}}
+            {{ .Values.webUi.image.repository }}@{{ .Values.webUi.image.digest }}
+            {{- else -}}
+            {{ .Values.webUi.image.repository }}:{{ .Values.webUi.image.tag | default "latest" }}
+            {{- end }}
+          ports:
+            - containerPort: 8334
+          volumeMounts:
+            - name: config
+              mountPath: /app/data/state/config
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ .Values.webUi.persistence.existingClaim }}
+{{- end }}

--- a/storj-gateway/templates/webui-ingress.yaml
+++ b/storj-gateway/templates/webui-ingress.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.webUi.enabled .Values.webUi.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "storj-gateway.fullname" . }}-webui
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- if .Values.webUi.ingress.tls.enabled }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: {{ .Values.webUi.ingress.tls.issuer }}
+    {{- else }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.webUi.ingress.className }}
+  {{- if .Values.webUi.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.webUi.ingress.host }}
+      secretName: {{ .Values.webUi.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.webUi.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "storj-gateway.fullname" . }}-webui
+                port:
+                  number: 80
+{{- end }}

--- a/storj-gateway/templates/webui-pvc.yaml
+++ b/storj-gateway/templates/webui-pvc.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.webUi.enabled .Values.webUi.persistence.enabled .Values.webUi.persistence.create }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.webUi.persistence.existingClaim }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.webUi.persistence.size }}
+  storageClassName: {{ .Values.webUi.persistence.storageClassName | quote }}
+{{- end }}

--- a/storj-gateway/templates/webui-service.yaml
+++ b/storj-gateway/templates/webui-service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webUi.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "storj-gateway.fullname" . }}-webui
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "storj-gateway.name" . }}-webui
+  ports:
+    - port: 80
+      targetPort: 8334
+      protocol: TCP
+      name: http
+{{- end }}

--- a/storj-gateway/values.yaml
+++ b/storj-gateway/values.yaml
@@ -70,3 +70,29 @@ persistence:
   mountPath: /root/.local/share/storj/gateway  # Path estándar donde storj guarda su configuración
   accessMode: ReadWriteOnce                 # Modo de acceso típico para un solo pod
   size: 5Mi                                 # Tamaño mínimo requerido por storj para almacenar config y caché
+
+# WebUI
+webUi:
+  enabled: true
+
+  image:
+    repository: machines/filestash
+    # digest: "sha256:7fd7a33a0a0e8c724b5180d4d1732dd41d0525ead8d4509e37f93d83b33eaf52"
+    tag: "latest"
+
+  ingress:
+    enabled: true
+    className: nginx
+    host: filestash.cluster.local
+    tls:
+      enabled: true
+      issuer: vault-issuer
+      secretName: filestash-tls
+
+  persistence:
+    enabled: true
+    create: true
+    existingClaim: filestash-config-pvc
+    storageClassName: longhorn
+    size: 50Mi
+


### PR DESCRIPTION
This PR adds optional Filestash integration into the Storj Gateway Helm chart. Includes configurable image, TLS Ingress, persistence, and issuer.