### PR TITLE
fix(makefile): configura identidad de Git en update-readme-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ template: ## 🔍 Renderiza manifest con template
 install: ## 🚀 Simula instalación (--dry-run --debug)
 	helm install $(CHART_NAME)-test ./$(CHART_DIR) -f $(CHART_DIR)/values.yaml --dry-run --debug
 
+add-repo: ## 🔗 Añade el repositorio Helm mhorcajada y actualiza el índice
+	@helm repo add mhorcajada $(REPO_URL) || true
+	@helm repo update || true
+
 update-readme-version: ## 📝 Sustituye versión en README.md si CHART_VERSION > LATEST_VERSION
 	@git config user.name "github-actions"
 	@git config user.email "github-actions@github.com"
@@ -124,7 +128,7 @@ sync-index: clean-cache ## 🔄 Refresca el repo Helm local
 	sleep 5
 	helm search repo mhorcajada/$(CHART_NAME) --versions
 
-release:  precheck lint template update-readme-version package save-artifacts push-main push-gh-pages create-tag sync-index ## 📦 Publica el chart completo. Uso: make release CHART_VERSION=0.x.x   y   make release
+release:  precheck lint template add-repo update-readme-version package save-artifacts push-main push-gh-pages create-tag sync-index ## 📦 Publica el chart completo. Uso: make release CHART_VERSION=0.x.x   y   make release
 	@echo "\n✅ Publicación completada:"
 	@echo "🔗 Chart URL: $(REPO_URL)/$(CHART_NAME)-$(CHART_VERSION).tgz"
 	@echo "📦 Añade el repo con:"

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ install: ## 🚀 Simula instalación (--dry-run --debug)
 	helm install $(CHART_NAME)-test ./$(CHART_DIR) -f $(CHART_DIR)/values.yaml --dry-run --debug
 
 update-readme-version: ## 📝 Sustituye versión en README.md si CHART_VERSION > LATEST_VERSION
+	@git config user.name "github-actions"
+	@git config user.email "github-actions@github.com"
 	@LATEST_VERSION=$$(curl -s $(REPO_URL)/index.yaml | yq '.entries["$(CHART_NAME)"][0].version' | tr -d '"'); \
 	if [ -z "$$LATEST_VERSION" ]; then \
 		echo "❌ No se pudo obtener la versión remota desde $(REPO_URL)/index.yaml"; exit 1; \

--- a/storj-gateway/Chart.yaml
+++ b/storj-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: storj-gateway
 description: A Helm chart for deploying Storj Gateway with Vault-injected secrets.
-version: 0.3.3
+version: 0.3.4
 appVersion: "1.10.0"
 kubeVersion: ">= 1.21.0"
 keywords:


### PR DESCRIPTION
Este PR garantiza que los commits realizados por GitHub Actions desde el Makefile lleven correctamente la identidad de usuario (nombre y email), evitando errores como '@invalid-email-address' en el historial de cambios y changelog generados por git-cliff.